### PR TITLE
Rails31

### DIFF
--- a/lib/erector/rails/railtie.rb
+++ b/lib/erector/rails/railtie.rb
@@ -1,6 +1,6 @@
 module Erector
   class Railtie < ::Rails::Railtie
-    config.generators.template_engine :erector
+    config.app_generators.template_engine :erector
 
     # TODO: automatically add app directory to app.config.autoload_paths,
     # so that Views::Foo::Bar autoloads, and 'require "views/foo/bar.html"'

--- a/lib/erector/rails/template_handler.rb
+++ b/lib/erector/rails/template_handler.rb
@@ -1,6 +1,6 @@
 module Erector
   module Rails
-    class TemplateHandler < ActionView::Template::Handler
+    class TemplateHandler
       def self.call(template)
         require_dependency template.identifier
         widget_class_name = "views/#{template.identifier =~ %r(views/([^.]*)(\..*)?\.rb) && $1}".camelize

--- a/spec/rails_root/config/environments/development.rb
+++ b/spec/rails_root/config/environments/development.rb
@@ -11,7 +11,6 @@ RailsRoot::Application.configure do
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
-  config.action_view.debug_rjs             = true
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send


### PR DESCRIPTION
We made these changes on a branch called rails31, which I don't know how to express as a pull request. They probably aren't rails3.0 compatible, but they eliminate some deprecation warnings on rails 3.
